### PR TITLE
Fix for liquidation risk, background color and some css

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -5,8 +5,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
-
 @layer base {
   @font-face {
     font-family: 'GT Super Display';
@@ -64,6 +62,7 @@
   body {
     @apply font-secondary;
     background-image: url(../img/app-bg.jpg);
+    background-color: #002133;
     background-size: cover;
     overflow: hidden;
   }

--- a/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.stories.tsx
+++ b/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.stories.tsx
@@ -7,7 +7,6 @@ export default {
     args: {
         collateralCoverage: 70,
         totalCollateralInUSD: 100,
-        liquidationPercentage: 23,
     },
 } as ComponentMeta<typeof CollateralManagementConciseTab>;
 

--- a/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.test.tsx
+++ b/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.test.tsx
@@ -12,9 +12,9 @@ describe('CollateralManagementConciseTab component', () => {
         expect(screen.getByText('$70')).toBeInTheDocument();
 
         expect(screen.getByText('Liquidation Risk')).toBeInTheDocument();
-        expect(screen.getByText('Threshold 23%')).toBeInTheDocument();
-        expect(screen.getByText('Low')).toBeInTheDocument();
-        expect(screen.getByText('Low')).toHaveClass('text-progressBarStart');
+        expect(screen.getByText('Threshold 10%')).toBeInTheDocument();
+        expect(screen.getByText('High')).toBeInTheDocument();
+        expect(screen.getByText('High')).toHaveClass('text-progressBarEnd');
 
         expect(screen.getByTestId('collateral-progress-bar-track')).toHaveStyle(
             'width: calc(100% * 0.7)'
@@ -22,19 +22,26 @@ describe('CollateralManagementConciseTab component', () => {
     });
 
     it('should render correct color and risk status', () => {
-        render(<Default liquidationPercentage={0} />);
-        expect(screen.getByText('Threshold 0%')).toBeInTheDocument();
+        render(<Default collateralCoverage={0} />);
+        expect(screen.getByText('Threshold 80%')).toBeInTheDocument();
         expect(screen.getByText('N/A')).toBeInTheDocument();
         expect(screen.getByText('N/A')).toHaveClass('text-white');
 
-        render(<Default liquidationPercentage={50} />);
+        render(<Default collateralCoverage={30} />);
         expect(screen.getByText('Threshold 50%')).toBeInTheDocument();
+        expect(screen.getByText('Low')).toBeInTheDocument();
+        expect(screen.getByText('Low')).toHaveClass('text-progressBarStart');
+
+        render(<Default collateralCoverage={50} />);
+        expect(screen.getByText('Threshold 30%')).toBeInTheDocument();
         expect(screen.getByText('Medium')).toBeInTheDocument();
         expect(screen.getByText('Medium')).toHaveClass('text-progressBarVia');
 
-        render(<Default liquidationPercentage={70} />);
-        expect(screen.getByText('Threshold 70%')).toBeInTheDocument();
-        expect(screen.getByText('High')).toBeInTheDocument();
-        expect(screen.getByText('High')).toHaveClass('text-progressBarEnd');
+        render(<Default collateralCoverage={90} />);
+        expect(screen.getByText('Threshold 0%')).toBeInTheDocument();
+        expect(screen.getByText('Liquidated')).toBeInTheDocument();
+        expect(screen.getByText('Liquidated')).toHaveClass(
+            'text-progressBarEnd'
+        );
     });
 });

--- a/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.tsx
+++ b/src/components/atoms/CollateralManagementConciseTab/CollateralManagementConciseTab.tsx
@@ -1,18 +1,16 @@
 import { Separator } from 'src/components/atoms/Separator';
-import { percentFormat, usdFormat } from 'src/utils';
+import { LIQUIDATION_THRESHOLD, percentFormat, usdFormat } from 'src/utils';
 
 interface CollateralManagementConciseTabProps {
     collateralCoverage: number;
     totalCollateralInUSD: number;
-    liquidationPercentage: number;
 }
 
 export const CollateralManagementConciseTab = ({
     collateralCoverage,
     totalCollateralInUSD,
-    liquidationPercentage,
 }: CollateralManagementConciseTabProps) => {
-    const info = getLiquidationInformation(liquidationPercentage);
+    const info = getLiquidationInformation(collateralCoverage);
 
     return (
         <div className='flex h-fit w-full flex-col bg-black-20 pt-2 pb-4'>
@@ -51,7 +49,9 @@ export const CollateralManagementConciseTab = ({
                         </span>
                         <span className='typography-caption-3 text-slateGray'>
                             {`Threshold ${percentFormat(
-                                liquidationPercentage
+                                LIQUIDATION_THRESHOLD > collateralCoverage
+                                    ? LIQUIDATION_THRESHOLD - collateralCoverage
+                                    : 0
                             )}`}
                         </span>
                     </div>
@@ -72,6 +72,8 @@ export const getLiquidationInformation = (liquidationPercentage: number) => {
         return { color: 'text-progressBarStart', risk: 'Low' };
     } else if (liquidationPercentage >= 40 && liquidationPercentage < 60) {
         return { color: 'text-progressBarVia', risk: 'Medium' };
+    } else if (liquidationPercentage >= 60 && liquidationPercentage < 80) {
+        return { color: 'text-progressBarEnd', risk: 'High' };
     }
-    return { color: 'text-progressBarEnd', risk: 'High' };
+    return { color: 'text-progressBarEnd', risk: 'Liquidated' };
 };

--- a/src/components/molecules/CollateralTabRightPane/CollateralTabRightPane.test.tsx
+++ b/src/components/molecules/CollateralTabRightPane/CollateralTabRightPane.test.tsx
@@ -27,6 +27,7 @@ describe('CollateralTabRightPane component', () => {
         expect(screen.getByText('50%')).toBeInTheDocument();
 
         expect(screen.getByText('Liquidation Risk')).toBeInTheDocument();
-        expect(screen.getAllByText('N/A')).toHaveLength(2);
+        expect(screen.getByText('Low')).toBeInTheDocument();
+        expect(screen.getByText('43%')).toBeInTheDocument();
     });
 });

--- a/src/components/molecules/CollateralTabRightPane/CollateralTabRightPane.tsx
+++ b/src/components/molecules/CollateralTabRightPane/CollateralTabRightPane.tsx
@@ -32,7 +32,9 @@ export const CollateralTabRightPane = ({
                 totalCollateralInUSD={balance}
                 collateralCoverage={collateralUsagePercent}
             />
-            <LiquidationProgressBar liquidationPercentage={0} />
+            <LiquidationProgressBar
+                liquidationPercentage={collateralUsagePercent}
+            />
         </div>
     );
 };

--- a/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.stories.tsx
+++ b/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.stories.tsx
@@ -16,5 +16,5 @@ const Template: ComponentStory<typeof LiquidationProgressBar> = args => (
 export const Default = Template.bind({});
 export const ConnectedToWallet = Template.bind({});
 ConnectedToWallet.args = {
-    liquidationPercentage: 40,
+    liquidationPercentage: 45,
 };

--- a/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.test.tsx
+++ b/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.test.tsx
@@ -20,8 +20,8 @@ describe('LiquidationProgressBar Component', () => {
         render(<ConnectedToWallet />);
 
         expect(screen.getByText('Liquidation Risk')).toBeInTheDocument();
-        expect(screen.getByText('40%')).toBeInTheDocument();
-        expect(screen.getByText('40%')).toHaveClass('text-progressBarVia');
+        expect(screen.getByText('35%')).toBeInTheDocument();
+        expect(screen.getByText('35%')).toHaveClass('text-progressBarVia');
         expect(
             screen.getByText('threshold to liquidation')
         ).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('LiquidationProgressBar Component', () => {
         expect(screen.getByText('Medium')).toHaveClass('text-progressBarVia');
 
         expect(screen.getByTestId('liquidation-progress-bar-tick')).toHaveStyle(
-            'width: calc(100% * 0.5 + 4px )'
+            'width: calc(100% * 0.5625 + 4px )'
         );
 
         const information = screen.getByTestId('information-circle');
@@ -37,22 +37,30 @@ describe('LiquidationProgressBar Component', () => {
 
         expect(
             screen.getByText(
-                'You are currently at 40% to liquidation. Upon reaching the liquidation threshold (80% LTV), 50% of assets will automatically be liquidated to repay the lender. Liquidation will be subject to 5% liquation fee.'
+                'You are currently at 35% to liquidation. Upon reaching the liquidation threshold (80% LTV), 50% of assets will automatically be liquidated to repay the lender. Liquidation will be subject to 5% liquation fee.'
             )
         ).toBeInTheDocument();
     });
 
     it('should render correct color and risk status', () => {
         render(<Default liquidationPercentage={10} />);
-        expect(screen.getByText('10%')).toBeInTheDocument();
-        expect(screen.getByText('10%')).toHaveClass('text-progressBarStart');
+        expect(screen.getByText('70%')).toBeInTheDocument();
+        expect(screen.getByText('70%')).toHaveClass('text-progressBarStart');
         expect(screen.getByText('Low')).toBeInTheDocument();
         expect(screen.getByText('Low')).toHaveClass('text-progressBarStart');
 
         render(<Default liquidationPercentage={70} />);
-        expect(screen.getByText('70%')).toBeInTheDocument();
-        expect(screen.getByText('70%')).toHaveClass('text-progressBarEnd');
+        expect(screen.getByText('10%')).toBeInTheDocument();
+        expect(screen.getByText('10%')).toHaveClass('text-progressBarEnd');
         expect(screen.getByText('High')).toBeInTheDocument();
         expect(screen.getByText('High')).toHaveClass('text-progressBarEnd');
+
+        render(<Default liquidationPercentage={90} />);
+        expect(screen.getByText('0%')).toBeInTheDocument();
+        expect(screen.getByText('0%')).toHaveClass('text-progressBarEnd');
+        expect(screen.getByText('Liquidated')).toBeInTheDocument();
+        expect(screen.getByText('Liquidated')).toHaveClass(
+            'text-progressBarEnd'
+        );
     });
 });

--- a/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.tsx
+++ b/src/components/molecules/LiquidationProgressBar/LiquidationProgressBar.tsx
@@ -3,6 +3,7 @@ import {
     getLiquidationInformation,
     InformationPopover,
 } from 'src/components/atoms';
+import { LIQUIDATION_THRESHOLD } from 'src/utils';
 
 interface LiquidationProgressBarProps {
     liquidationPercentage: number;
@@ -10,13 +11,17 @@ interface LiquidationProgressBarProps {
 
 const formatInformationText = (liquidationPercentage: number) => {
     if (liquidationPercentage === 0) return '';
-    return `You are currently at ${liquidationPercentage}% to liquidation. Upon reaching the liquidation threshold (80% LTV), 50% of assets will automatically be liquidated to repay the lender. Liquidation will be subject to 5% liquation fee.`;
+    return `You are currently at ${
+        LIQUIDATION_THRESHOLD > liquidationPercentage
+            ? LIQUIDATION_THRESHOLD - liquidationPercentage
+            : 0
+    }% to liquidation. Upon reaching the liquidation threshold (80% LTV), 50% of assets will automatically be liquidated to repay the lender. Liquidation will be subject to 5% liquation fee.`;
 };
 
 export const LiquidationProgressBar = ({
     liquidationPercentage = 0,
 }: LiquidationProgressBarProps) => {
-    let padding = liquidationPercentage * 0.0125;
+    let padding = liquidationPercentage / LIQUIDATION_THRESHOLD;
     if (padding > 1) {
         padding = 1;
     }
@@ -56,7 +61,13 @@ export const LiquidationProgressBar = ({
                             <span
                                 className={`whitespace-pre font-semibold ${info.color}`}
                             >
-                                {`${liquidationPercentage}% `}
+                                {`${
+                                    LIQUIDATION_THRESHOLD >
+                                    liquidationPercentage
+                                        ? LIQUIDATION_THRESHOLD -
+                                          liquidationPercentage
+                                        : 0
+                                }% `}
                             </span>
                             <span className='text-planetaryPurple'>
                                 threshold to liquidation

--- a/src/components/molecules/Tab/Tab.tsx
+++ b/src/components/molecules/Tab/Tab.tsx
@@ -16,7 +16,7 @@ export const Tab: React.FC<TabProps> = ({ tabDataArray, children }) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
 
     return (
-        <div className='h-full w-full overflow-hidden rounded-br-2xl rounded-bl-2xl border border-white-10 bg-cardBackground/60 shadow-tab'>
+        <div className='h-full w-full rounded-br-2xl rounded-bl-2xl border border-white-10 bg-cardBackground/60 shadow-tab'>
             <HeadlessTab.Group
                 selectedIndex={selectedIndex}
                 onChange={setSelectedIndex}

--- a/src/components/organisms/MarketDashboardOrderCard/MarketDashboardOrderCard.test.tsx
+++ b/src/components/organisms/MarketDashboardOrderCard/MarketDashboardOrderCard.test.tsx
@@ -37,24 +37,8 @@ describe('MarketDashboardOrderCard Component', () => {
         expect(screen.getByText('$80')).toBeInTheDocument();
 
         expect(screen.getByText('Liquidation Risk')).toBeInTheDocument();
-        expect(screen.getByText('Threshold 0%')).toBeInTheDocument();
-        expect(screen.getByText('N/A')).toBeInTheDocument();
-
-        expect(screen.getByTestId('collateral-progress-bar-track')).toHaveStyle(
-            'width: calc(100% * 0.08)'
-        );
-    });
-
-    it('should render collateralmanagementconcisetab', () => {
-        render(<Default />);
-        expect(screen.getByText('Collateral Management')).toBeInTheDocument();
-        expect(screen.getByText('Collateral')).toBeInTheDocument();
-        expect(screen.getByText('Utilization 8%')).toBeInTheDocument();
-        expect(screen.getByText('$80')).toBeInTheDocument();
-
-        expect(screen.getByText('Liquidation Risk')).toBeInTheDocument();
-        expect(screen.getByText('Threshold 0%')).toBeInTheDocument();
-        expect(screen.getByText('N/A')).toBeInTheDocument();
+        expect(screen.getByText('Threshold 72%')).toBeInTheDocument();
+        expect(screen.getByText('Low')).toBeInTheDocument();
 
         expect(screen.getByTestId('collateral-progress-bar-track')).toHaveStyle(
             'width: calc(100% * 0.08)'

--- a/src/components/organisms/MarketDashboardOrderCard/MarketDashboardOrderCard.tsx
+++ b/src/components/organisms/MarketDashboardOrderCard/MarketDashboardOrderCard.tsx
@@ -167,7 +167,6 @@ export const MarketDashboardOrderCard = ({
                 <CollateralManagementConciseTab
                     collateralCoverage={collateralUsagePercent}
                     totalCollateralInUSD={balance}
-                    liquidationPercentage={0}
                 />
             </div>
         </div>

--- a/src/utils/currencies.tsx
+++ b/src/utils/currencies.tsx
@@ -53,3 +53,4 @@ export const generateWalletInformation = (
 };
 
 export const COLLATERAL_THRESHOLD = 74; // in percentage %
+export const LIQUIDATION_THRESHOLD = 80; // in percentage %


### PR DESCRIPTION
1. Involving logic for liquidation risk.
2. Adding background colour to body.
3. Tab component had overflow-hidden, which was removed.