### PR TITLE
build: add workflow to merge into main [SF-227]

### DIFF
--- a/.github/workflows/merge-into-main.yml
+++ b/.github/workflows/merge-into-main.yml
@@ -1,0 +1,34 @@
+name: Merge into main
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit ID'
+        required: false
+        type: string
+
+jobs:
+  deploy:
+    name: Merge into main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.MACHINE_USER_APP_ID }}
+          private_key: ${{ secrets.MACHINE_USER_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Merge into main
+        shell: bash
+        run: |
+          git config user.name "SF Machine User[bot]"
+          git config user.email "${{ secrets.MACHINE_USER_APP_ID }}+sf-machine-user[bot]@users.noreply.github.com"
+          git switch main
+          git merge ${{ github.event.inputs.commit || 'develop' }}
+          git push


### PR DESCRIPTION
Workflow to merge directly from Github `develop` into `main`. 
This will automatically triggers deployment in `staging` environment.