### PR TITLE
fix: update names if there are multiple maturity with the same one [SF-442]

### DIFF
--- a/src/hooks/useLendingMarkets/useLendingMarkets.ts
+++ b/src/hooks/useLendingMarkets/useLendingMarkets.ts
@@ -43,6 +43,16 @@ export const useLendingMarkets = (
                                         midUnitPrice,
                                     }
                                 ) => {
+                                    if (acc[name]) {
+                                        // If the name already exists in the accumulator
+                                        // Increment the name by appending a number
+                                        let i = 1;
+                                        while (acc[`${name}-${i}`]) {
+                                            i++;
+                                        }
+                                        name = `${name}-${i}`;
+                                    }
+
                                     return {
                                         ...acc,
                                         [name]: {
@@ -58,6 +68,7 @@ export const useLendingMarkets = (
                                 },
                                 {}
                             ),
+
                             ccy
                         )
                     );


### PR DESCRIPTION
Add a counter in the name of the contract in case there is multiple ones with the same name.
This is used for development environment only.

![image](https://user-images.githubusercontent.com/767647/230460524-a5875861-1805-4711-92c5-e8c397746dad.png)
