### PR TITLE
build: add versioning in main [SF-398]

### DIFF
--- a/.github/workflows/merge-into-main.yml
+++ b/.github/workflows/merge-into-main.yml
@@ -36,7 +36,8 @@ jobs:
           git switch main
           git merge ${{ github.event.inputs.commit || 'develop' }}
           if [ "${{ github.event.inputs.hotfix }}" = "true" ]; then
-            npm version patch
+            npm version patch -m "Hotfix: %s"
           else
-            npm version minor
+            npm version minor -m "Release: %s"
           fi
+          git push --follow-tags


### PR DESCRIPTION
There is a new step when merging `develop` in `main`. 
It will now use `npm version` to tag and commit the version number in `package.json`

This was not tested so please help me reviewing it.