### PR TITLE
fix: fix color bar position on safari [SF-554]

### DIFF
--- a/src/components/atoms/ColorBar/ColorBar.test.tsx
+++ b/src/components/atoms/ColorBar/ColorBar.test.tsx
@@ -10,17 +10,17 @@ describe('ColorBar Component', () => {
         render(<Default />);
     });
 
-    it('should have always a width of at least 3%', () => {
+    it('should have always a width of at least 80%', () => {
         render(
-            <Default value={BigNumber.from(1)} total={BigNumber.from(100)} />
+            <Default value={BigNumber.from(0)} total={BigNumber.from(100)} />
         );
-        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 3%');
+        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 80%');
     });
 
-    it('should have a width of 90% when value is equal to total', () => {
+    it('should have a width of 300% when value is equal to total', () => {
         render(
             <Default value={BigNumber.from(100)} total={BigNumber.from(100)} />
         );
-        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 90%');
+        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 300%');
     });
 });

--- a/src/components/atoms/ColorBar/ColorBar.tsx
+++ b/src/components/atoms/ColorBar/ColorBar.tsx
@@ -3,7 +3,9 @@ import { BigNumber } from 'ethers';
 import { ColorFormat } from 'src/types';
 import { calculatePercentage } from 'src/utils/collateral';
 
-const COLORBAR_MIN_WIDTH = 3;
+const COLORBAR_MIN_WIDTH = 80;
+const COLORBAR_MAX_WIDTH = 300;
+const COLORBAR_MAGNIFIER = 1.5;
 export const ColorBar = ({
     value,
     total,
@@ -14,17 +16,26 @@ export const ColorBar = ({
     total: BigNumber;
     align: 'left' | 'right';
 } & Required<ColorFormat>) => {
-    const width = Math.max(
-        COLORBAR_MIN_WIDTH,
-        Math.trunc(calculatePercentage(value, total).toNumber() / 1.1)
+    const width = Math.min(
+        Math.max(
+            COLORBAR_MIN_WIDTH,
+            Math.trunc(
+                COLORBAR_MIN_WIDTH +
+                    Math.pow(
+                        calculatePercentage(value, total).toNumber(),
+                        COLORBAR_MAGNIFIER
+                    )
+            )
+        ),
+        COLORBAR_MAX_WIDTH
     );
     return (
         <div
-            className={classNames('absolute bottom-1 h-4/6', {
+            className={classNames('absolute h-[120%]', {
                 'bg-galacticOrange/20': color === 'negative',
                 'bg-nebulaTeal/20': color === 'positive',
-                'left-0.5': align === 'left',
-                'right-0.5': align === 'right',
+                '-left-0.5': align === 'left',
+                '-right-0.5': align === 'right',
             })}
             data-testid='color-bar'
             style={{ width: `${width}%` }}

--- a/src/components/molecules/CoreTable/CoreTable.tsx
+++ b/src/components/molecules/CoreTable/CoreTable.tsx
@@ -83,7 +83,7 @@ export const CoreTable = <T,>({
                                 data-testid={`${coreTableOptions.name}-header-cell`}
                                 key={header.id}
                                 className={classNames(
-                                    'relative px-1 py-2 text-center font-bold',
+                                    'px-1 py-2 text-center font-bold',
                                     {
                                         'sticky left-0 z-10 bg-black-20/100 tablet:bg-transparent':
                                             columnIndex === 0 &&
@@ -107,7 +107,7 @@ export const CoreTable = <T,>({
                 {table.getRowModel().rows.map(row => (
                     <tr
                         key={row.id}
-                        className={classNames('relative h-7', {
+                        className={classNames('h-7', {
                             'cursor-pointer': coreTableOptions.hoverRow?.(
                                 row.id
                             ),

--- a/src/components/organisms/OrderWidget/OrderWidget.tsx
+++ b/src/components/organisms/OrderWidget/OrderWidget.tsx
@@ -85,10 +85,13 @@ const PriceCell = ({
     if (amount.eq(0)) return <OrderBookCell />;
     return (
         <div
-            className={classNames('flex', {
-                'justify-start': align === 'left',
-                'justify-end': align === 'right',
-            })}
+            className={classNames(
+                'relative flex items-center overflow-visible',
+                {
+                    'justify-start': align === 'left',
+                    'justify-end': align === 'right',
+                }
+            )}
         >
             <OrderBookCell
                 value={formatLoanValue(value, 'price')}


### PR DESCRIPTION
![image](https://github.com/Secured-Finance/secured-finance-app/assets/767647/66711d90-e9a7-46f8-af6a-5a13a36a633d)
Chrome and Safari

App is now usabe:
![image](https://github.com/Secured-Finance/secured-finance-app/assets/767647/fc34debf-5b71-4d29-afa0-af56ba8dc1a6)
