### PR TITLE
fix: fix collateral threshold bar and placeholder [SF-602]

### DIFF
--- a/src/components/atoms/OrderInputBox/OrderInputBox.tsx
+++ b/src/components/atoms/OrderInputBox/OrderInputBox.tsx
@@ -6,7 +6,7 @@ import { amountFormatterToBase, CurrencySymbol } from 'src/utils';
 interface OrderInputBoxProps {
     field: string;
     unit?: string;
-    initialValue?: number | string;
+    initialValue?: number | string | undefined;
     asset?: CurrencySymbol;
     disabled?: boolean;
     informationText?: string;
@@ -18,7 +18,7 @@ interface OrderInputBoxProps {
 export const OrderInputBox = ({
     field,
     unit,
-    initialValue = 0,
+    initialValue,
     asset,
     disabled = false,
     informationText,

--- a/src/components/molecules/CollateralProgressBar/CollateralProgressBar.tsx
+++ b/src/components/molecules/CollateralProgressBar/CollateralProgressBar.tsx
@@ -51,6 +51,8 @@ export const CollateralProgressBar = ({
         collateralThreshold
     );
 
+    const barWidth = Math.min(1, collateralCoverage);
+
     return (
         <div
             className='pointer-events-none flex flex-col gap-3 rounded-lg px-5 pb-12 pt-6 hover:bg-black-20'
@@ -69,18 +71,18 @@ export const CollateralProgressBar = ({
             <div className='flex flex-col gap-[6px]'>
                 <div
                     style={{
-                        width: `calc(100% * ${collateralCoverage} + 4px )`,
+                        width: `calc(100% * ${barWidth} + 4px )`,
                     }}
                     className='transition-width duration-700 ease-in'
                     data-testid='collateral-progress-bar-tick'
                 >
                     <Tick className='float-right h-5px w-2'></Tick>
                 </div>
-                <div className='relative h-5px w-full overflow-hidden rounded-full bg-black-60'>
+                <div className='h-5px w-full rounded-full bg-black-60'>
                     <div
                         className='float-left h-full bg-nebulaTeal transition-width duration-700 ease-in'
                         style={{
-                            width: `calc(100% * ${collateralCoverage})`,
+                            width: `calc(100% * ${barWidth})`,
                         }}
                         data-testid='collateral-progress-bar-track'
                     ></div>

--- a/src/components/organisms/AdvancedLending/AdvancedLending.test.tsx
+++ b/src/components/organisms/AdvancedLending/AdvancedLending.test.tsx
@@ -29,9 +29,7 @@ describe('Advanced Lending Component', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Filecoin' }));
         fireEvent.click(screen.getByRole('menuitem', { name: 'USDC' }));
         expect(store.getState().landingOrderForm.amount).toEqual('0');
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
     });
 
     it('should reset the amount when the user change the maturity', async () => {
@@ -50,9 +48,7 @@ describe('Advanced Lending Component', () => {
         fireEvent.click(screen.getByRole('button', { name: 'DEC22' }));
         fireEvent.click(screen.getByText('MAR23'));
         expect(store.getState().landingOrderForm.amount).toEqual('0');
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
     });
 
     it('should show the maturity as a date for the selected maturity', async () => {

--- a/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.test.tsx
+++ b/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.test.tsx
@@ -186,7 +186,7 @@ describe('AdvancedLendingOrderCard Component', () => {
 
         const slider = screen.getByRole('slider');
         const input = screen.getByRole('textbox', { name: 'Amount' });
-        expect(input).toHaveValue('0.0000');
+        expect(input).toHaveValue('');
         fireEvent.change(slider, { target: { value: 50 } });
         expect(input).toHaveValue('50');
         fireEvent.change(slider, { target: { value: 100 } });
@@ -218,7 +218,7 @@ describe('AdvancedLendingOrderCard Component', () => {
         const option = screen.getByTestId('option-1');
         fireEvent.click(option);
 
-        expect(input).toHaveValue('0');
+        expect(input).toHaveValue('');
         expect(slider).toHaveValue('0');
     });
 
@@ -252,7 +252,7 @@ describe('AdvancedLendingOrderCard Component', () => {
         expect(screen.getByText('SF Vault')).toBeInTheDocument();
         const option = screen.getByTestId('option-1');
         fireEvent.click(option);
-        expect(input).toHaveValue('0');
+        expect(input).toHaveValue('');
         fireEvent.change(slider, { target: { value: 100 } });
         expect(input).toHaveValue('100');
     });

--- a/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.tsx
+++ b/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.tsx
@@ -39,6 +39,7 @@ import {
     percentFormat,
     usdFormat,
     amountFormatterFromBase,
+    ZERO_BN,
 } from 'src/utils';
 import { Amount, LoanValue } from 'src/utils/entities';
 import { useWallet } from 'use-wallet';
@@ -87,7 +88,9 @@ export const AdvancedLendingOrderCard = ({
 
     const price = priceList[currency];
 
-    const orderAmount = new Amount(amount, currency);
+    const orderAmount = amount.gt(ZERO_BN)
+        ? new Amount(amount, currency)
+        : undefined;
 
     const availableToBorrow = useMemo(() => {
         return currency && assetPriceMap
@@ -250,13 +253,13 @@ export const AdvancedLendingOrderCard = ({
                     field='Amount'
                     unit={currency}
                     asset={currency}
-                    initialValue={orderAmount.value}
+                    initialValue={orderAmount?.value}
                     onValueChange={v => handleInputChange(BigNumber.from(v))}
                 />
                 <div className='mx-10px flex flex-col gap-6'>
                     <OrderDisplayBox
                         field='Est. Present Value'
-                        value={usdFormat(orderAmount.toUSD(price), 2)}
+                        value={usdFormat(orderAmount?.toUSD(price) ?? 0, 2)}
                     />
                     <OrderDisplayBox
                         field='Future Value'

--- a/src/components/pages/Itayose/Itayose.test.tsx
+++ b/src/components/pages/Itayose/Itayose.test.tsx
@@ -35,8 +35,6 @@ describe('Itayose Component', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Filecoin' }));
         fireEvent.click(screen.getByRole('menuitem', { name: 'USDC' }));
         expect(store.getState().landingOrderForm.amount).toEqual('0');
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
     });
 });

--- a/src/components/pages/Landing/Landing.test.tsx
+++ b/src/components/pages/Landing/Landing.test.tsx
@@ -103,9 +103,7 @@ describe('Landing Component', () => {
             });
             fireEvent.click(screen.getByText('Advanced'));
         });
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
         expect(screen.getByRole('textbox', { name: 'Bond Price' })).toHaveValue(
             '96.85'
         );
@@ -136,9 +134,7 @@ describe('Landing Component', () => {
         fireEvent.click(screen.getByText('MAR23'));
         expect(screen.getByText('MAR23')).toBeInTheDocument();
 
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
         expect(screen.getByRole('textbox', { name: 'Bond Price' })).toHaveValue(
             '96.83'
         );
@@ -168,9 +164,7 @@ describe('Landing Component', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Filecoin' }));
         fireEvent.click(screen.getByRole('menuitem', { name: 'USDC' }));
 
-        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue(
-            '0'
-        );
+        expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveValue('');
         expect(screen.getByRole('textbox', { name: 'Bond Price' })).toHaveValue(
             '96.85'
         );


### PR DESCRIPTION
This PR has fix for SF-602 and removes the 0 from empty field so that the placeholder is visible in Advanced Lending and Itayose