### PR TITLE
fix: move from day to seconds in apr calculation [SF-612]

### DIFF
--- a/src/components/molecules/AdvancedLendingTopBar/AdvancedLendingTopBar.test.tsx
+++ b/src/components/molecules/AdvancedLendingTopBar/AdvancedLendingTopBar.test.tsx
@@ -19,7 +19,7 @@ describe('AdvancedLendingTopBar Component', () => {
         expect(screen.getByText('24h Volume')).toBeInTheDocument();
         expect(screen.getAllByText('0')).toHaveLength(5);
         expect(screen.getByText('80.00')).toBeInTheDocument();
-        expect(screen.getByText('25.07% APR')).toBeInTheDocument();
+        expect(screen.getByText('25.03% APR')).toBeInTheDocument();
     });
 
     it('should render the values on the AdvancedLendingTopBar', () => {

--- a/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.test.tsx
+++ b/src/components/organisms/AdvancedLendingOrderCard/AdvancedLendingOrderCard.test.tsx
@@ -75,7 +75,7 @@ describe('AdvancedLendingOrderCard Component', () => {
             expect(inputs[0].getAttribute('value')).toBe('95');
 
             expect(screen.getByText('Fixed Rate (APR)')).toBeInTheDocument();
-            expect(screen.getByText('17%')).toBeInTheDocument();
+            expect(screen.getByText('16.91%')).toBeInTheDocument();
 
             expect(screen.getByText('Amount')).toBeInTheDocument();
             expect(inputs[1].getAttribute('value')).toBe('500');

--- a/src/components/pages/Landing/Landing.test.tsx
+++ b/src/components/pages/Landing/Landing.test.tsx
@@ -55,7 +55,7 @@ describe('Landing Component', () => {
 
         await waitFor(() => {
             expect(screen.getByTestId('market-rate')).toHaveTextContent(
-                '3.93%'
+                '3.92%'
             );
         });
 

--- a/src/utils/entities/loanValue.test.ts
+++ b/src/utils/entities/loanValue.test.ts
@@ -56,14 +56,14 @@ describe('LoanValue class', () => {
         const maturityDec24 = new Maturity(1712492800);
 
         const prices: [number, Maturity, number][] = [
-            [9626, maturityMar23, 228731],
-            [9595, maturityJun23, 124245],
-            [9585, maturitySep23, 85423],
-            [9580, maturityDec23, 64785],
-            [9571, maturityMar24, 53118],
-            [9565, maturityJun24, 44850],
-            [9560, maturitySep24, 38842],
-            [9555, maturityDec24, 34276],
+            [9626, maturityMar23, 226902],
+            [9595, maturityJun23, 124171],
+            [9585, maturitySep23, 85125],
+            [9580, maturityDec23, 64727],
+            [9571, maturityMar24, 52981],
+            [9565, maturityJun24, 44804],
+            [9560, maturitySep24, 38755],
+            [9555, maturityDec24, 34239],
         ];
 
         prices.forEach(([price, maturity, apr]) => {
@@ -75,7 +75,7 @@ describe('LoanValue class', () => {
 });
 
 describe('APR calculation edge cases', () => {
-    it('should return an o APR if the price is 100', () => {
+    it('should return a zero APR if the price is 100', () => {
         const loanValue = LoanValue.fromPrice(10000, 1712492800);
         expect(loanValue.apr.toNumber()).toEqual(0);
     });

--- a/src/utils/entities/loanValue.ts
+++ b/src/utils/entities/loanValue.ts
@@ -1,4 +1,5 @@
 import * as dayjs from 'dayjs';
+import { divide } from '../currencyList';
 import { Rate } from '../rate';
 
 export class LoanValue {
@@ -9,7 +10,7 @@ export class LoanValue {
 
     private static PAR_VALUE = 10000;
     private PAR_VALUE_RATE = 1000000;
-    private DAYS_IN_YEAR = 365;
+    private SECONDS_IN_YEAR = 365 * 24 * 60 * 60;
 
     private constructor() {
         // do nothing
@@ -108,10 +109,10 @@ export class LoanValue {
     }
 
     private dayToMaturity(): number {
-        return dayjs.unix(this._maturity).diff(Date.now(), 'day');
+        return dayjs.unix(this._maturity).diff(Date.now(), 'second');
     }
 
     private yearFraction(): number {
-        return this.dayToMaturity() / this.DAYS_IN_YEAR;
+        return divide(this.dayToMaturity(), this.SECONDS_IN_YEAR, 10);
     }
 }

--- a/src/utils/portfolio.test.ts
+++ b/src/utils/portfolio.test.ts
@@ -1,22 +1,22 @@
 import { BigNumber, utils } from 'ethers';
 import { AssetPriceMap } from 'src/store/assetPrices/selectors';
+import {
+    dec22Fixture,
+    efilBytes32,
+    ethBytes32,
+    wbtcBytes32,
+} from 'src/stories/mocks/fixtures';
 import { TradeHistory } from 'src/types';
 import timemachine from 'timemachine';
 import { CurrencySymbol } from './currencyList';
 import {
+    calculateAveragePrice,
+    calculateForwardValue,
+    checkOrderIsFilled,
     computeNetValue,
     computeWeightedAverageRate,
-    calculateForwardValue,
-    calculateAveragePrice,
     formatOrders,
-    checkOrderIsFilled,
 } from './portfolio';
-import {
-    dec22Fixture,
-    ethBytes32,
-    efilBytes32,
-    wbtcBytes32,
-} from 'src/stories/mocks/fixtures';
 
 beforeAll(() => {
     timemachine.reset();
@@ -46,7 +46,7 @@ describe('computeWeightedAverage', () => {
             computeWeightedAverageRate(
                 trades as unknown as TradeHistory
             ).toNumber()
-        ).toEqual(196880);
+        ).toEqual(196748);
     });
 
     it('should return 0 if no trades are provided', () => {


### PR DESCRIPTION
<img width="991" alt="Screenshot 2023-06-29 at 1 59 10 PM" src="https://github.com/Secured-Finance/secured-finance-app/assets/49697136/44af74c1-c7bf-4b04-bf2d-35af1fcc8ad9">
<img width="986" alt="Screenshot 2023-06-29 at 1 59 19 PM" src="https://github.com/Secured-Finance/secured-finance-app/assets/49697136/0c291bd1-87b8-481c-8e03-dbb68039a69a">
