### PR TITLE
fix: use max amount as reference for color bar [SF-767]

### DIFF
--- a/src/components/atoms/ColorBar/ColorBar.test.tsx
+++ b/src/components/atoms/ColorBar/ColorBar.test.tsx
@@ -10,11 +10,11 @@ describe('ColorBar Component', () => {
         render(<Default />);
     });
 
-    it('should have a width of at least 20% when value is not null', () => {
+    it('should have a width of at least 5% when value is not null', () => {
         render(
             <Default value={BigNumber.from(1)} total={BigNumber.from(1000)} />
         );
-        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 20%');
+        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 5%');
     });
 
     it('should have a width of 2px when value is zero', () => {
@@ -24,10 +24,17 @@ describe('ColorBar Component', () => {
         expect(screen.getByTestId('color-bar')).toHaveStyle('width: 2px');
     });
 
-    it('should have a width of 300% when value is equal to total', () => {
+    it('should have a width of 308% when value is equal to total', () => {
         render(
             <Default value={BigNumber.from(100)} total={BigNumber.from(100)} />
         );
-        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 300%');
+        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 308%');
+    });
+
+    it('should have a width of 5% when value is 1 and total is 1000', () => {
+        render(
+            <Default value={BigNumber.from(1)} total={BigNumber.from(1000)} />
+        );
+        expect(screen.getByTestId('color-bar')).toHaveStyle('width: 5%');
     });
 });

--- a/src/components/atoms/ColorBar/ColorBar.tsx
+++ b/src/components/atoms/ColorBar/ColorBar.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import { BigNumber } from 'ethers';
 import { ColorFormat } from 'src/types';
+import { divide, multiply } from 'src/utils';
 import { calculatePercentage } from 'src/utils/collateral';
 
-const COLORBAR_MIN_WIDTH = 20;
-const COLORBAR_MAX_WIDTH = 300;
-const COLORBAR_MAGNIFIER = 1.5;
+const COLORBAR_MIN_WIDTH = 5;
+const COLORBAR_MAX_WIDTH = 308;
 export const ColorBar = ({
     value,
     total,
@@ -18,14 +18,11 @@ export const ColorBar = ({
 } & Required<ColorFormat>) => {
     const width = Math.min(
         Math.max(
-            COLORBAR_MIN_WIDTH,
-            Math.trunc(
-                COLORBAR_MIN_WIDTH +
-                    Math.pow(
-                        calculatePercentage(value, total).toNumber(),
-                        COLORBAR_MAGNIFIER
-                    )
-            )
+            multiply(
+                divide(calculatePercentage(value, total).toNumber(), 100),
+                COLORBAR_MAX_WIDTH
+            ),
+            COLORBAR_MIN_WIDTH
         ),
         COLORBAR_MAX_WIDTH
     );

--- a/src/components/organisms/OrderBookWidget/OrderBookWidget.tsx
+++ b/src/components/organisms/OrderBookWidget/OrderBookWidget.tsx
@@ -27,6 +27,7 @@ import {
     CurrencySymbol,
     currencyMap,
     formatLoanValue,
+    getMaxAmount,
     ordinaryFormat,
 } from 'src/utils';
 import { LoanValue } from 'src/utils/entities';
@@ -236,23 +237,12 @@ export const OrderBookWidget = ({
         aggregationFactor
     );
 
-    const totalBuyAmount = useMemo(
-        () =>
-            borrowOrders.reduce(
-                (acc, order) => acc.add(order.amount),
-                BigNumber.from(0)
-            ),
+    const maxBorrowAmount = useMemo(
+        () => getMaxAmount(borrowOrders),
         [borrowOrders]
     );
 
-    const totalSellAmount = useMemo(
-        () =>
-            lendOrders.reduce(
-                (acc, order) => acc.add(order.amount),
-                BigNumber.from(0)
-            ),
-        [lendOrders]
-    );
+    const maxLendAmount = useMemo(() => getMaxAmount(lendOrders), [lendOrders]);
 
     const buyColumns = useMemo(
         () => [
@@ -262,7 +252,7 @@ export const OrderBookWidget = ({
                     <PriceCell
                         value={info.getValue()}
                         amount={info.row.original.amount}
-                        totalAmount={totalBuyAmount}
+                        totalAmount={maxBorrowAmount}
                         aggregationFactor={aggregationFactor}
                         position='borrow'
                         align='left'
@@ -289,7 +279,7 @@ export const OrderBookWidget = ({
                 header: () => <TableHeader title='APR' align='right' />,
             }),
         ],
-        [aggregationFactor, currency, totalBuyAmount]
+        [aggregationFactor, currency, maxBorrowAmount]
     );
 
     const sellColumns = useMemo(
@@ -318,7 +308,7 @@ export const OrderBookWidget = ({
                     <PriceCell
                         value={info.getValue()}
                         amount={info.row.original.amount}
-                        totalAmount={totalSellAmount}
+                        totalAmount={maxLendAmount}
                         aggregationFactor={aggregationFactor}
                         position='lend'
                         align='left'
@@ -327,7 +317,7 @@ export const OrderBookWidget = ({
                 header: () => <TableHeader title='Price' align='left' />,
             }),
         ],
-        [aggregationFactor, currency, totalSellAmount]
+        [aggregationFactor, currency, maxLendAmount]
     );
 
     const handleClick = (rowId: string, side: OrderSide): void => {

--- a/src/utils/portfolio.test.ts
+++ b/src/utils/portfolio.test.ts
@@ -3,11 +3,11 @@ import { AssetPriceMap } from 'src/store/assetPrices/selectors';
 import {
     dec22Fixture,
     ethBytes32,
+    orderHistoryList,
     wbtcBytes32,
     wfilBytes32,
-    orderHistoryList,
 } from 'src/stories/mocks/fixtures';
-import { TradeHistory, OrderType } from 'src/types';
+import { OrderType, TradeHistory } from 'src/types';
 import timemachine from 'timemachine';
 import { CurrencySymbol } from './currencyList';
 import {
@@ -17,6 +17,7 @@ import {
     computeNetValue,
     computeWeightedAverageRate,
     formatOrders,
+    getMaxAmount,
     sortOrders,
 } from './portfolio';
 
@@ -300,4 +301,28 @@ describe('sortOrders', () => {
             sortedOrders[i + 1].createdAt.toNumber()
         );
     }
+});
+
+describe('getMaxAmount', () => {
+    it('returns the maximum amount from an array of orders', () => {
+        const orders = [
+            { amount: BigNumber.from(10) },
+            { amount: BigNumber.from(5) },
+            { amount: BigNumber.from(20) },
+        ];
+        const maxAmount = getMaxAmount(orders);
+        expect(maxAmount.toString()).toBe('20');
+    });
+
+    it('returns the amount of the only order in the array', () => {
+        const orders = [{ amount: BigNumber.from(10) }];
+        const maxAmount = getMaxAmount(orders);
+        expect(maxAmount.toString()).toBe('10');
+    });
+
+    it('returns zero if the array is empty', () => {
+        const orders: { amount: BigNumber }[] = [];
+        const maxAmount = getMaxAmount(orders);
+        expect(maxAmount.toString()).toBe('0');
+    });
 });

--- a/src/utils/portfolio.ts
+++ b/src/utils/portfolio.ts
@@ -1,11 +1,10 @@
 import { BigNumber } from 'ethers';
+import { OrderList, Position } from 'src/hooks';
 import { AssetPriceMap } from 'src/store/assetPrices/selectors';
-import { TradeHistory } from 'src/types';
+import { Order, TradeHistory } from 'src/types';
 import { currencyMap, hexToCurrencySymbol } from './currencyList';
 import { LoanValue } from './entities';
 import { Rate } from './rate';
-import { OrderList, Position } from 'src/hooks';
-import { Order } from 'src/types';
 
 export const computeWeightedAverageRate = (trades: TradeHistory) => {
     if (!trades.length) {
@@ -93,4 +92,14 @@ export const checkOrdersAreSame = (order1: Order, order2: OrderList[0]) => {
 
 export const sortOrders = (a: Order, b: Order) => {
     return Number(b.createdAt.sub(a.createdAt));
+};
+
+export const getMaxAmount = (orders: { amount: BigNumber }[]) => {
+    if (!orders.length) {
+        return BigNumber.from(0);
+    }
+    return orders.reduce(
+        (prev, current) => (prev.gt(current.amount) ? prev : current.amount),
+        orders[0].amount
+    );
 };


### PR DESCRIPTION
The color bars in the orderbook were calculated compared to the total amount in the orderbook.
They are now calculated according to the max amount.