### PR TITLE
fix: navbar to top of the page to maintain visibility on scroll [SF-918]

### DIFF
--- a/src/components/templates/Layout/Layout.tsx
+++ b/src/components/templates/Layout/Layout.tsx
@@ -13,8 +13,11 @@ export const Layout = ({
             data-testid='wrapper-div'
         >
             <div className='w-full'>
-                <header className='w-full'>{navBar}</header>
-                <main className='w-full'>{children}</main>
+                <header className='fixed top-0 z-50 w-full backdrop-blur'>
+                    {navBar}
+                </header>
+                {/* The header has a height of h-20, and the main section has a top margin of mt-6. However, since the header is fixed, the actual top margin of the main section is mt-26 after calculation. */}
+                <main className='mt-26 w-full'>{children}</main>
             </div>
             <footer className='w-full'>{footer}</footer>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
             margin: {
                 '0.5': '0.125rem',
                 '10px': '10px',
+                '26': '6.5rem',
             },
             transitionProperty: {
                 width: 'width',


### PR DESCRIPTION
This PR is designed to update the navigation bar to be fixed at the top of the browser. Key features include:
1. As the page is scrolled, the navigation bar remains fixed at the top of the browser, ensuring constant access to navigation.
2. When the navigation bar overlaps content, a frosted glass effect is applied to obscure the underlying content, enhancing both functionality and aesthetics.