### PR TITLE
feat: navbar to top of the page to maintain visibility on scroll [SF-918]

### DIFF
--- a/src/components/templates/Layout/Layout.tsx
+++ b/src/components/templates/Layout/Layout.tsx
@@ -13,7 +13,9 @@ export const Layout = ({
             data-testid='wrapper-div'
         >
             <div className='w-full'>
-                <header className='w-full'>{navBar}</header>
+                <header className='sticky top-0 z-50 w-full bg-universeBlue'>
+                    {navBar}
+                </header>
                 <main className='w-full'>{children}</main>
             </div>
             <footer className='w-full'>{footer}</footer>


### PR DESCRIPTION
This PR is designed to update the navigation bar to be fixed at the top of the browser. Key features include:

1. As the page is scrolled, the navigation bar remains fixed at the top of the browser, ensuring constant access to navigation.
2. if set "w-screen" = 100vw, when the vertical scroll bar appears, the horizontal scroll bar will appears too, have fixed it