### PR TITLE
fix: fix header block the dialog on small sceen [SF-935]

### DIFF
--- a/src/components/templates/Layout/Layout.tsx
+++ b/src/components/templates/Layout/Layout.tsx
@@ -13,7 +13,7 @@ export const Layout = ({
             data-testid='wrapper-div'
         >
             <div className='w-full'>
-                <header className='sticky top-0 z-50 w-full bg-universeBlue'>
+                <header className='sticky top-0 z-30 w-full bg-universeBlue'>
                     {navBar}
                 </header>
                 <main className='w-full'>{children}</main>


### PR DESCRIPTION
before header's z-index is higher than dialog. so have this problem
![image](https://github.com/Secured-Finance/secured-finance-app/assets/28584664/6a0fc862-ccb4-4a20-806b-4d6998b72e4b)
![image](https://github.com/Secured-Finance/secured-finance-app/assets/28584664/fadb927a-8ad8-4269-8dba-e07ffa236bcb)
