### PR TITLE
test: Verify Claude GitHub Action on v2 branch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/README-CLAUDE-TEST.md
+++ b/README-CLAUDE-TEST.md
@@ -1,0 +1,10 @@
+# Claude GitHub Action Test
+
+This is a test file to verify @claude mentions work on PRs to v2 branch.
+
+## Test Scenarios
+- [ ] @claude can respond to mentions in PR comments
+- [ ] Claude Code Review runs automatically on PR creation
+- [ ] Claude can analyze code changes
+
+Test timestamp: 2024-12-XX


### PR DESCRIPTION
## Test PR for Claude GitHub Action

This PR tests if @claude mentions work on PRs to the v2 branch.

### Test Scenarios
- [ ] @claude responds to mentions in PR comments
- [ ] Claude Code Review runs automatically
- [ ] Claude can analyze code changes

### Note
This is a test PR to verify the Claude GitHub Action functionality after the workflow files were merged to the default branch (develop).

@claude Can you see this mention and respond?